### PR TITLE
feat: selectedDetentIdentifier environment value

### DIFF
--- a/Example/Example.swiftpm/ContentView.swift
+++ b/Example/Example.swiftpm/ContentView.swift
@@ -83,9 +83,17 @@ struct SheetContentView: View {
   @State
   private var widthFollowsPreferredContentSizeWhenEdgeAttached = false
 
+  @Environment(\.selectedDetentIdentifier)
+  private var selectedDetent
+
   var body: some View {
     NavigationView {
       List {
+        Section {
+          Text(selectedDetent?.rawValue ?? "nil")
+        } header: {
+          Text("Selected Detent Identifier")
+        }
         Section {
           Text(count, format: .number)
           Button("Increment") { count += 1 }

--- a/Sources/BottomSheetPresenter.swift
+++ b/Sources/BottomSheetPresenter.swift
@@ -174,6 +174,7 @@ extension BottomSheetPresenter {
         }.onPreferenceChange(DismissDisabledPreferenceKey.self) { [self] preference in
           dismissDisabled = preference
         }
+        .selectedDetentIdentifier(self.viewController?.sheetPresentationController?.selectedDetentIdentifier)
     }
 
     private func resetItemBinding() {
@@ -187,6 +188,15 @@ extension BottomSheetPresenter {
     private func resetItemBindingAndHandleDismissal() {
       parent.item = nil
       parent.onDismiss?()
+    }
+
+    // MARK: UISheetPresentationControllerDelegate
+    func sheetPresentationControllerDidChangeSelectedDetentIdentifier(_ sheetPresentationController: UISheetPresentationController) {
+      guard let item = item else {
+        return
+      }
+
+      updateSheet(with: item)
     }
 
     // MARK: UIAdaptivePresentationControllerDelegate

--- a/Sources/Environment+SelectedDetentIdentifier.swift
+++ b/Sources/Environment+SelectedDetentIdentifier.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+private struct SelectedDetentIdentifierKey: EnvironmentKey {
+  static let defaultValue: UISheetPresentationController.Detent.Identifier? = nil
+}
+
+extension EnvironmentValues {
+  public var selectedDetentIdentifier: UISheetPresentationController.Detent.Identifier? {
+    get { self[SelectedDetentIdentifierKey.self] }
+  }
+
+  var _selectedDetentIdentifier: UISheetPresentationController.Detent.Identifier? {
+    get { self[SelectedDetentIdentifierKey.self] }
+    set { self[SelectedDetentIdentifierKey.self] = newValue }
+  }
+}
+
+extension View {
+  func selectedDetentIdentifier(_ id: UISheetPresentationController.Detent.Identifier? = nil) -> some View {
+    self.environment(\._selectedDetentIdentifier, id)
+  }
+}


### PR DESCRIPTION
## Description
Can see the current `selectedDetentIdentifier` in the content view. 

Useful for updating the content view based on a given detent.